### PR TITLE
timestamp from 0 and increase by fixed ms interval

### DIFF
--- a/platform-testing/sensor_csv_impulse/data_to_csv.py
+++ b/platform-testing/sensor_csv_impulse/data_to_csv.py
@@ -86,7 +86,7 @@ def collect_data(sampler: Sampler, interval_ms: int, sample_length: int) -> list
     # time.time() is not guaranteed to be accurate so we'll use it for timestamps and
     # time.perf_counter() for tracking time intervals.
     interval_secs = interval_ms/1000
-    data_timestamp = time.time()
+    data_timestamp = 0 
     start_counter = time.perf_counter()
     current_counter = start_counter
 
@@ -101,7 +101,8 @@ def collect_data(sampler: Sampler, interval_ms: int, sample_length: int) -> list
         if delta_time(current_counter) < interval_secs:
             pass
         else:
-            data_timestamp += delta_time(current_counter)
+            # Timestamp entries are expected to be in milliseconds.
+            data_timestamp += interval_ms
             # reading_start = time.perf_counter() # debugging only
             reading = sampler.read_sensors()
             # print("reading took", time.perf_counter() - reading_start, "secs") # debugging only


### PR DESCRIPTION
Attempt to fix CSV import leading to 0 sec samples. According to Edge Impulse documentation on [Importing CSV Data](https://docs.edgeimpulse.com/reference/data-ingestion/importing-csv-data):

> For multi-axis, time-series data, the first column name must be timestamp in millisecond format. It should have constant intervals between lines (ie: 16 below), the data ingestion service will infer the sampling frequency from the intervals.

My strategy is:

- Data timestamps should start from time 0ms.
- Data timestamps should be in milliseconds (previously in seconds from `perf_count( )`
- Time between data points should be fixed interval, even if not 100% accurate.